### PR TITLE
Upgraded .NET Core SDK version to 1.0.0 preview2

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "projects": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0-preview1-002702"
+    "version": "1.0.0-preview2-003121"
   }
 }


### PR DESCRIPTION
It fixes `.NET Core SDK Not Found` error produced when using latest .NET Core SDK version (1.0.0-preview2-003121).

![error](https://cloud.githubusercontent.com/assets/3959458/17044946/b59c4e72-4f92-11e6-9924-09f483aaf448.png)
