### PR TITLE
Add configuration to in memory database in Startup.cs

### DIFF
--- a/test/AbpCompanyName.AbpProjectName.Web.Tests/Startup.cs
+++ b/test/AbpCompanyName.AbpProjectName.Web.Tests/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace AbpCompanyName.AbpProjectName.Web.Tests
 {
@@ -51,7 +52,8 @@ namespace AbpCompanyName.AbpProjectName.Web.Tests
         private void UseInMemoryDb(IServiceProvider serviceProvider)
         {
             var builder = new DbContextOptionsBuilder<AbpProjectNameDbContext>();
-            builder.UseInMemoryDatabase(Guid.NewGuid().ToString()).UseInternalServiceProvider(serviceProvider);
+            builder.UseInMemoryDatabase(Guid.NewGuid().ToString()).UseInternalServiceProvider(serviceProvider)
+                .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning));
             var options = builder.Options;
 
             var iocManager = serviceProvider.GetRequiredService<IIocManager>();


### PR DESCRIPTION
While following this article on CodeProject https://www.codeproject.com/Articles/1115763/Using-ASP-NET-Core-Entity-Framework-Core-and-ASP-N I found that the Should_Get_Tasks_By_State test returned an internal server error, while the application seemed to work fine.

After some debugging I found that this was related to Transactions not being supported by the in-memory store in EF Core.

It's only a warning and can easily be disregarded by adding this to configuration of the in memory database:
```
.ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
```

For more info on this see: https://github.com/aspnet/EntityFrameworkCore/issues/2866