### PR TITLE
Remove duplicate path in .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,6 @@ AppPackages/
 [Bb]in
 [Oo]bj
 sql
-TestResults
 [Tt]est[Rr]esult*
 *.Cache
 ClientBin


### PR DESCRIPTION
This pr removes duplicate `TestResults` path from .gitignore file.